### PR TITLE
fix(unity): Before generating the sprite asset, reorder the JSON file.

### DIFF
--- a/Assets/KyubEmojiSearchAPI/Editor/KyubEditor.EmojiSearch.asmdef
+++ b/Assets/KyubEmojiSearchAPI/Editor/KyubEditor.EmojiSearch.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "KyubEditor.EmojiSearch",
+    "rootNamespace": "",
     "references": [
         "Kyub.EmojiSearch",
         "Unity.TextMeshPro.Editor",
@@ -10,8 +11,10 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Newtonsoft.Json.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [

--- a/Assets/KyubEmojiSearchAPI/Tests/Editor.meta
+++ b/Assets/KyubEmojiSearchAPI/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26eb6f2b91f80446dbff72f43e5e3431
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime.meta
+++ b/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e05e7620885e4619b190e1fa491c686
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/EmojiSpriteJsonReorderTests.cs
+++ b/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/EmojiSpriteJsonReorderTests.cs
@@ -1,0 +1,190 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using static KyubEditor.EmojiSearch.EmojiDataConversorUtility;
+
+namespace KyubEditor.EmojiSearch
+{
+    public class EmojiSpriteJsonReorderTests 
+    {
+        [TestFixture]
+        public class EmojiJsonReorderHelperTests
+        {
+            private const string TestData =
+    @"[
+    {
+        ""name"": ""PHOENIX"",
+        ""unified"": ""1F426-200D-1F525"",
+        ""non_qualified"": null,
+        ""docomo"": null,
+        ""au"": null,
+        ""softbank"": null,
+        ""google"": null,
+        ""image"": ""1f426-200d-1f525.png"",
+        ""sheet_x"": 11,
+        ""sheet_y"": 34,
+        ""short_name"": ""phoenix"",
+        ""short_names"": [
+            ""phoenix""
+        ],
+        ""text"": null,
+        ""texts"": null,
+        ""category"": ""Animals & Nature"",
+        ""subcategory"": ""animal-bird"",
+        ""sort_order"": 646,
+        ""added_in"": ""15.1"",
+        ""has_img_apple"": true,
+        ""has_img_google"": true,
+        ""has_img_twitter"": false,
+        ""has_img_facebook"": false
+    },
+    {
+        ""name"": ""BLACK BIRD"",
+        ""unified"": ""1F426-200D-2B1B"",
+        ""non_qualified"": null,
+        ""docomo"": null,
+        ""au"": null,
+        ""softbank"": null,
+        ""google"": null,
+        ""image"": ""1f426-200d-2b1b.png"",
+        ""sheet_x"": 11,
+        ""sheet_y"": 35,
+        ""short_name"": ""black_bird"",
+        ""short_names"": [
+            ""black_bird""
+        ],
+        ""text"": null,
+        ""texts"": null,
+        ""category"": ""Animals & Nature"",
+        ""subcategory"": ""animal-bird"",
+        ""sort_order"": 644,
+        ""added_in"": ""15.0"",
+        ""has_img_apple"": true,
+        ""has_img_google"": true,
+        ""has_img_twitter"": true,
+        ""has_img_facebook"": true
+    },
+    {
+        ""name"": ""BIRD"",
+        ""unified"": ""1F426"",
+        ""non_qualified"": null,
+        ""docomo"": ""E74F"",
+        ""au"": ""E4E0"",
+        ""softbank"": ""E521"",
+        ""google"": ""FE1C8"",
+        ""image"": ""1f426.png"",
+        ""sheet_x"": 11,
+        ""sheet_y"": 36,
+        ""short_name"": ""bird"",
+        ""short_names"": [
+            ""bird""
+        ],
+        ""text"": null,
+        ""texts"": null,
+        ""category"": ""Animals & Nature"",
+        ""subcategory"": ""animal-bird"",
+        ""sort_order"": 631,
+        ""added_in"": ""0.6"",
+        ""has_img_apple"": true,
+        ""has_img_google"": true,
+        ""has_img_twitter"": true,
+        ""has_img_facebook"": true
+    }]";
+
+            private const string ExpectedResult =
+    @"[
+    {
+        ""name"": ""BIRD"",
+        ""unified"": ""1F426"",
+        ""non_qualified"": null,
+        ""docomo"": ""E74F"",
+        ""au"": ""E4E0"",
+        ""softbank"": ""E521"",
+        ""google"": ""FE1C8"",
+        ""image"": ""1f426.png"",
+        ""sheet_x"": 11,
+        ""sheet_y"": 36,
+        ""short_name"": ""bird"",
+        ""short_names"": [
+            ""bird""
+        ],
+        ""text"": null,
+        ""texts"": null,
+        ""category"": ""Animals & Nature"",
+        ""subcategory"": ""animal-bird"",
+        ""sort_order"": 631,
+        ""added_in"": ""0.6"",
+        ""has_img_apple"": true,
+        ""has_img_google"": true,
+        ""has_img_twitter"": true,
+        ""has_img_facebook"": true
+    },
+    {
+        ""name"": ""PHOENIX"",
+        ""unified"": ""1F426-200D-1F525"",
+        ""non_qualified"": null,
+        ""docomo"": null,
+        ""au"": null,
+        ""softbank"": null,
+        ""google"": null,
+        ""image"": ""1f426-200d-1f525.png"",
+        ""sheet_x"": 11,
+        ""sheet_y"": 34,
+        ""short_name"": ""phoenix"",
+        ""short_names"": [
+            ""phoenix""
+        ],
+        ""text"": null,
+        ""texts"": null,
+        ""category"": ""Animals & Nature"",
+        ""subcategory"": ""animal-bird"",
+        ""sort_order"": 646,
+        ""added_in"": ""15.1"",
+        ""has_img_apple"": true,
+        ""has_img_google"": true,
+        ""has_img_twitter"": false,
+        ""has_img_facebook"": false
+    },
+    {
+        ""name"": ""BLACK BIRD"",
+        ""unified"": ""1F426-200D-2B1B"",
+        ""non_qualified"": null,
+        ""docomo"": null,
+        ""au"": null,
+        ""softbank"": null,
+        ""google"": null,
+        ""image"": ""1f426-200d-2b1b.png"",
+        ""sheet_x"": 11,
+        ""sheet_y"": 35,
+        ""short_name"": ""black_bird"",
+        ""short_names"": [
+            ""black_bird""
+        ],
+        ""text"": null,
+        ""texts"": null,
+        ""category"": ""Animals & Nature"",
+        ""subcategory"": ""animal-bird"",
+        ""sort_order"": 644,
+        ""added_in"": ""15.0"",
+        ""has_img_apple"": true,
+        ""has_img_google"": true,
+        ""has_img_twitter"": true,
+        ""has_img_facebook"": true
+    }]";
+
+        [Test]
+        public void ReorderJsonData_ShouldSortCorrectly()
+        {
+            // Arrange
+            // Act
+            var resultJson = EmojiDataConversorUtility.ReorderJsonData(TestData);
+
+            var resultList = JsonConvert.DeserializeObject<List<PreConvertedImgData>>(resultJson);
+            var expectedList = JsonConvert.DeserializeObject<List<PreConvertedImgData>>(ExpectedResult);
+
+            // Assert
+            Assert.AreEqual(JsonConvert.SerializeObject(resultList), JsonConvert.SerializeObject(expectedList));
+        }
+        }
+    }
+}

--- a/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/EmojiSpriteJsonReorderTests.cs.meta
+++ b/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/EmojiSpriteJsonReorderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 023225b8a33df4ecfa9ffe9c070637a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/KyubEditor.EmojiSearch.Tests.asmdef
+++ b/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/KyubEditor.EmojiSearch.Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "KyubEditor.EmojiSearch.Tests",
+    "rootNamespace": "KyubEditor.EmojiSearch",
+    "references": [
+        "GUID:56e1c9c4f4e998c40a70ee9e76d48c50",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Newtonsoft.Json.dll",
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/KyubEditor.EmojiSearch.Tests.asmdef.meta
+++ b/Assets/KyubEmojiSearchAPI/Tests/Editor/Runtime/KyubEditor.EmojiSearch.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ad2cbae6daa5f4a618afaa610ea283cd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When using the package, there's an issue where 🐦 is displayed as 🐦‍🔥.
The reason is that during the sorting process, 🐦‍🔥 is placed before 🐦 in the JSON file.
Both have Unicode starting with 1F426:

- 🐦 is 1F426
- 🐦‍🔥 is 1F426-200D-1F525

As a result, when 🐦 is looked up, it matches 1F426-200D-1F525 first and returns the wrong result.
After adjusting the sorting and regenerating the asset file, the display becomes correct.